### PR TITLE
ci: add PR title validation workflow

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,32 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            fix
+            feat
+            docs
+            refactor
+            test
+            style
+            chore
+            build
+            ci
+            revert
+            perf
+            deprecate
+          requireScope: false


### PR DESCRIPTION
Add PR title validation workflow to enforce Conventional Commit PR title convention explained [here](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes).

For ESF/Kura add-ons the scope field will be left free-form (i.e. won't be checked against a list of allowed scopes).

Signed-off-by: Mattia Dal Ben [matthewdibi@gmail.com](mailto:matthewdibi@gmail.com)