### PR TITLE
ci: add version uptick automation workflow

### DIFF
--- a/.github/version_uptick_configs/uptick_major_on_develop_branch.yml
+++ b/.github/version_uptick_configs/uptick_major_on_develop_branch.yml
@@ -1,0 +1,19 @@
+---
+exclusions:
+  - "**/.git/**/*"
+  - "**/.github/**/*"
+  - "**/target/**/*"
+  - "**/RELEASE_INFO/**/*"
+  - "**/.settings/**/*"
+  - "**/.classpath"
+  - "**/.project"
+
+tasks:
+  - selector:
+      snapshot
+    actions:
+      - print
+      - transform_version:
+        - add_major: 1
+        - set_minor: 0
+        - set_patch: 0

--- a/.github/version_uptick_configs/uptick_minor_on_develop_branch.yml
+++ b/.github/version_uptick_configs/uptick_minor_on_develop_branch.yml
@@ -1,0 +1,18 @@
+---
+exclusions:
+  - "**/.git/**/*"
+  - "**/.github/**/*"
+  - "**/target/**/*"
+  - "**/RELEASE_INFO/**/*"
+  - "**/.settings/**/*"
+  - "**/.classpath"
+  - "**/.project"
+
+tasks:
+  - selector:
+      snapshot
+    actions:
+      - print
+      - transform_version:
+        - add_minor: 1
+        - set_patch: 0

--- a/.github/version_uptick_configs/uptick_patch_on_maintenance_branch.yml
+++ b/.github/version_uptick_configs/uptick_patch_on_maintenance_branch.yml
@@ -1,0 +1,18 @@
+---
+exclusions:
+  - "**/.git/**/*"
+  - "**/.github/**/*"
+  - "**/target/**/*"
+  - "**/RELEASE_INFO/**/*"
+  - "**/.settings/**/*"
+  - "**/.classpath"
+  - "**/.project"
+
+tasks:
+  - selector:
+      release
+    actions:
+      - print
+      - transform_version:
+        - add_patch: 1
+        - snapshot: set

--- a/.github/version_uptick_configs/uptick_snapshot_to_release.yml
+++ b/.github/version_uptick_configs/uptick_snapshot_to_release.yml
@@ -1,0 +1,17 @@
+---
+exclusions:
+  - "**/.git/**/*"
+  - "**/.github/**/*"
+  - "**/target/**/*"
+  - "**/RELEASE_INFO/**/*"
+  - "**/.settings/**/*"
+  - "**/.classpath"
+  - "**/.project"
+
+tasks:
+  - selector:
+      snapshot
+    actions:
+      - print
+      - transform_version:
+        - snapshot: remove

--- a/.github/workflows/version-uptick.yml
+++ b/.github/workflows/version-uptick.yml
@@ -1,0 +1,63 @@
+name: Version uptick automation
+
+on:
+  workflow_dispatch:
+    inputs:
+        target_branch:
+          type: string
+          default: 'develop'
+          required: true
+        uptick_config:
+          type: choice
+          description: Configuration to use for the uptick
+          options:
+            - uptick_major_on_develop_branch.yml
+            - uptick_minor_on_develop_branch.yml
+            - uptick_patch_on_maintenance_branch.yml
+            - uptick_snapshot_to_release.yml
+          required: true
+
+jobs:
+  uptick:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.inputs.target_branch }}
+
+    - name: Download ESF version upticker tool
+      uses: carlosperate/download-file-action@v1
+      with:
+        file-url: https://kura-repo.s3.us-west-2.amazonaws.com/esf_upticker_tool/version-uptick-0.1.0-linux-x86_64
+
+    - name: Make the uptick tool executable
+      run: |
+        chmod +x ./version-uptick-0.1.0-linux-x86_64
+      shell: bash
+
+    - name: Run the uptick tool
+      run: |
+        ./version-uptick-0.1.0-linux-x86_64 \
+        --commit --trace process-versions \
+        --config-path .github/version_uptick_configs/${{ github.event.inputs.uptick_config }} \
+        --root-dir .
+      shell: bash
+
+    - name: Cleanup uptick tool
+      run: |
+        rm ./version-uptick-0.1.0-linux-x86_64
+      shell: bash
+
+    - name: Get version
+      id: get-version
+      uses: JActions/maven-version@v1.0.0
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v4
+      with:
+        title: "chore: automated uptick to ${{ steps.get-version.outputs.version }}"
+        commit-message: "chore: automated uptick to ${{ steps.get-version.outputs.version }}"
+        body: "Automated changes by _Version uptick automation_ action: automated uptick to ${{ steps.get-version.outputs.version }} version"
+        branch-suffix: short-commit-hash


### PR DESCRIPTION
Add version uptick automation.

**Description of the solution adopted:** This PR adds the Version Uptick automation workflow Github Action. It covers the most common use cases for version upticking:
- `uptick_snapshot_to_release.yml`: Remove the `snapshot` qualifier for a maintenance branch.
- `uptick_major_on_develop_branch.yml`: Uptick Major identifier on develop branch, preserving the `snapshot` qualifier and setting remaining version numbers to 0.
- `uptick_minor_on_develop_branch.yml`: Uptick Minor identifier on develop branch, preserving the `snapshot` qualifier and setting remaining version numbers to 0.
- `uptick_patch_on_maintenance_branch.yml`: Uptick maintenance branch from release to the next Patch number adding the `snapshot` qualifier.

The manual workflow accepts two parameters:
- `target_branch`: The branch on which to run the version uptick tool
- `uptick_config`: One of the available uptick tool configuration options (see above).

Once the uptick tool is run, the workflow will open a new PR on the target branch.

⚠️ **Note**: For this to work on branch others then the default one it needs to be backported to the desired branch. Failing to do so will generate an error during the workflow run because of the missing configuration files (the files inside `.github/version_uptick_configs`)

Signed-off-by: Mattia Dal Ben <matthewdibi@gmail.com>
