### PR TITLE
chore: add name property in pom (required for manifest builder automation)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,6 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.eurotech.framework.log</groupId>
     <artifactId>log4j-systemd-journal-appender</artifactId>
+    <name>log4j-systemd-journal-appender</name>
     <version>1.1.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <properties>


### PR DESCRIPTION
This PR adds the `name` property in the artifacts we're interested in uploading to S3 on release. This is required by the Manifest Builder automation detailed [here](https://github.com/eurotech/add-ons-automation/pull/22)

I used the manifest of the last release for populating the `name` properties.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>